### PR TITLE
Initialize Next.js app structure

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true
+  }
+}
+
+module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "portfolio",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.0.0",
+    "eslint": "^8.0.0",
+    "eslint-config-next": "^14.2.3",
+    "postcss": "^8.0.0",
+    "tailwindcss": "^3.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,10 @@
+import { profile } from '@/lib/data'
+
+export default function AboutPage() {
+  return (
+    <section className="space-y-4 p-8 bg-white/60 dark:bg-gray-800/60 backdrop-blur-lg rounded-xl">
+      <h2 className="text-3xl font-semibold">About Me</h2>
+      <p>{profile.bio}</p>
+    </section>
+  )
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,0 +1,8 @@
+export default function BlogPage() {
+  return (
+    <section className="space-y-4 p-8 bg-white/60 dark:bg-gray-800/60 backdrop-blur-lg rounded-xl">
+      <h2 className="text-3xl font-semibold">Blog</h2>
+      <p>Coming soon...</p>
+    </section>
+  )
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,8 @@
+export default function ContactPage() {
+  return (
+    <section className="space-y-4 p-8 bg-white/60 dark:bg-gray-800/60 backdrop-blur-lg rounded-xl">
+      <h2 className="text-3xl font-semibold">Contact</h2>
+      <p>Reach me at <a href="mailto:you@example.com" className="underline text-blue-600 dark:text-blue-400">you@example.com</a></p>
+    </section>
+  )
+}

--- a/src/app/experiments/page.tsx
+++ b/src/app/experiments/page.tsx
@@ -1,0 +1,8 @@
+export default function ExperimentsPage() {
+  return (
+    <section className="space-y-4 p-8 bg-white/60 dark:bg-gray-800/60 backdrop-blur-lg rounded-xl">
+      <h2 className="text-3xl font-semibold">Experiments</h2>
+      <p>Coming soon...</p>
+    </section>
+  )
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html {
+  scroll-behavior: smooth;
+}

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,0 +1,11 @@
+import { profile } from '@/lib/data'
+
+export default function LandingPage() {
+  return (
+    <section className="flex flex-col items-center justify-center gap-4 text-center p-8 bg-white/60 dark:bg-gray-800/60 backdrop-blur-lg rounded-xl">
+      <h1 className="text-4xl font-bold">Hi, I'm {profile.name}</h1>
+      <p className="text-xl text-gray-600 dark:text-gray-300">{profile.role}</p>
+      <p className="max-w-prose">{profile.bio}</p>
+    </section>
+  )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,20 @@
+import './globals.css'
+import ThemeToggle from '@/components/ThemeToggle'
+import type { Metadata } from 'next'
+import { ReactNode } from 'react'
+
+export const metadata: Metadata = {
+  title: 'Portfolio',
+  description: 'Personal portfolio site',
+}
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body className="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100 min-h-screen">
+        <ThemeToggle />
+        <main className="container mx-auto p-4">{children}</main>
+      </body>
+    </html>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,11 @@
+import { profile } from '@/lib/data'
+
+export default function HomePage() {
+  return (
+    <section className="flex flex-col items-center justify-center gap-4 text-center p-8 bg-white/60 dark:bg-gray-800/60 backdrop-blur-lg rounded-xl">
+      <h1 className="text-4xl font-bold">Hi, I'm {profile.name}</h1>
+      <p className="text-xl text-gray-600 dark:text-gray-300">{profile.role}</p>
+      <p className="max-w-prose">{profile.bio}</p>
+    </section>
+  )
+}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,0 +1,16 @@
+import { projects } from '@/lib/data'
+
+export default function ProjectsPage() {
+  return (
+    <section className="space-y-4 p-8 bg-white/60 dark:bg-gray-800/60 backdrop-blur-lg rounded-xl">
+      <h2 className="text-3xl font-semibold">Projects</h2>
+      <ul className="list-disc pl-4">
+        {projects.map((p) => (
+          <li key={p.title} className="mb-2">
+            <strong>{p.title}:</strong> {p.description}
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/src/app/technologies/page.tsx
+++ b/src/app/technologies/page.tsx
@@ -1,0 +1,16 @@
+import { technologies } from '@/lib/data'
+
+export default function TechnologiesPage() {
+  return (
+    <section className="space-y-4 p-8 bg-white/60 dark:bg-gray-800/60 backdrop-blur-lg rounded-xl">
+      <h2 className="text-3xl font-semibold">Technologies</h2>
+      <ul className="flex flex-wrap gap-2">
+        {technologies.map((tech) => (
+          <li key={tech} className="px-2 py-1 bg-gray-200/40 dark:bg-gray-700/40 rounded">
+            {tech}
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/src/app/testimonials/page.tsx
+++ b/src/app/testimonials/page.tsx
@@ -1,0 +1,17 @@
+import { testimonials } from '@/lib/data'
+
+export default function TestimonialsPage() {
+  return (
+    <section className="space-y-4 p-8 bg-white/60 dark:bg-gray-800/60 backdrop-blur-lg rounded-xl">
+      <h2 className="text-3xl font-semibold">Testimonials</h2>
+      <ul className="space-y-2">
+        {testimonials.map((t) => (
+          <li key={t.author} className="border-l-4 border-blue-500 pl-4">
+            <p className="italic">"{t.quote}"</p>
+            <p className="text-sm text-right">- {t.author}</p>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,34 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+export default function ThemeToggle() {
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  useEffect(() => {
+    const theme = localStorage.getItem('theme')
+    if (theme === 'dark') {
+      document.documentElement.classList.add('dark')
+    }
+  }, [])
+
+  if (!mounted) return null
+
+  const toggle = () => {
+    const isDark = document.documentElement.classList.toggle('dark')
+    localStorage.setItem('theme', isDark ? 'dark' : 'light')
+  }
+
+  return (
+    <button
+      onClick={toggle}
+      className="fixed bottom-4 right-4 p-2 bg-white/30 dark:bg-gray-800/30 backdrop-blur-md rounded-full"
+      aria-label="Toggle Theme"
+    >
+      🌗
+    </button>
+  )
+}

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1,0 +1,17 @@
+export const profile = {
+  name: 'Your Name',
+  role: 'Your Role',
+  bio: 'A short bio about yourself. Replace this with your real bio.',
+}
+
+export const projects = [
+  { title: 'Project One', description: 'Description of project one.' },
+  { title: 'Project Two', description: 'Description of project two.' },
+]
+
+export const technologies = ['TypeScript', 'React', 'Next.js', 'TailwindCSS']
+
+export const testimonials = [
+  { author: 'Jane Doe', quote: 'Great work!' },
+  { author: 'John Smith', quote: 'Amazing developer!' },
+]

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,14 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./src/**/*.{js,ts,jsx,tsx}"
+  ],
+  darkMode: 'class',
+  theme: {
+    extend: {
+      colors: {
+      }
+    },
+  },
+  plugins: [],
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.js"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- set up basic Next.js+Tailwind project skeleton
- add ThemeToggle component with dark/light mode
- create page sections (home, projects, technologies, about, blog, experiments, testimonials, contact)
- include placeholder profile and project data

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875c90ad2e48320bc28e0be29b7c945