### PR TITLE
Update portfolio pages with Tailwind styles

### DIFF
--- a/public/profile.svg
+++ b/public/profile.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="300" viewBox="0 0 300 300">
+  <rect width="300" height="300" fill="#e5e7eb"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="48" fill="#374151">Avatar</text>
+</svg>

--- a/public/project1.svg
+++ b/public/project1.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200">
+  <rect width="300" height="200" fill="#cbd5e1"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="24" fill="#1e293b">Project 1</text>
+</svg>

--- a/public/project2.svg
+++ b/public/project2.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200">
+  <rect width="300" height="200" fill="#d1fae5"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="24" fill="#065f46">Project 2</text>
+</svg>

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -2,9 +2,19 @@ import { profile } from '@/lib/data'
 
 export default function AboutPage() {
   return (
-    <section className="space-y-6 py-10">
-      <h2 className="text-4xl font-bold mb-4">About Me</h2>
-      <p className="max-w-prose text-gray-700 dark:text-gray-300">{profile.bio}</p>
+    <section className="space-y-6 py-10 max-w-3xl mx-auto">
+      <h2 className="text-4xl font-bold mb-4 text-center">About Me</h2>
+      <div className="flex flex-col items-center gap-4">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src="/profile.svg"
+          alt={profile.name}
+          className="w-32 h-32 rounded-full border border-gray-300 dark:border-gray-700"
+        />
+        <p className="max-w-prose text-center text-gray-700 dark:text-gray-300">
+          {profile.bio}
+        </p>
+      </div>
     </section>
   )
 }

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,12 +1,17 @@
 export default function ContactPage() {
   return (
-    <section className="space-y-6 py-10">
-      <h2 className="text-4xl font-bold mb-4">Contact</h2>
-      <p className="max-w-prose text-gray-700 dark:text-gray-300">
-        Reach me at{' '}
+    <section className="space-y-6 py-10 max-w-prose mx-auto">
+      <h2 className="text-4xl font-bold mb-4 text-center">Contact</h2>
+      <p className="text-gray-700 dark:text-gray-300 text-center">
+        Feel free to reach out via email at{' '}
         <a href="mailto:you@example.com" className="underline text-blue-600 dark:text-blue-400">
           you@example.com
         </a>
+        . You can also find me on{' '}
+        <a href="https://linkedin.com" className="underline text-blue-600 dark:text-blue-400">
+          LinkedIn
+        </a>
+        .
       </p>
     </section>
   )

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,8 @@ import { profile } from '@/lib/data'
 export default function HomePage() {
   return (
     <section className="flex flex-col items-center justify-center gap-6 text-center py-20">
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img src="/profile.svg" alt={profile.name} className="w-40 h-40 rounded-full border border-gray-300 dark:border-gray-700" />
       <h1 className="text-5xl font-bold bg-gradient-to-r from-blue-500 to-purple-600 bg-clip-text text-transparent">
         Hi, I'm {profile.name}
       </h1>

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -3,14 +3,22 @@ import { projects } from '@/lib/data'
 export default function ProjectsPage() {
   return (
     <section className="space-y-6 py-10">
-      <h2 className="text-4xl font-bold mb-4">Projects</h2>
-      <ul className="list-disc pl-5 space-y-2">
+      <h2 className="text-4xl font-bold mb-8 text-center">Projects</h2>
+      <div className="grid gap-6 md:grid-cols-2">
         {projects.map((p) => (
-          <li key={p.title} className="mb-2">
-            <strong>{p.title}:</strong> {p.description}
-          </li>
+          <div
+            key={p.title}
+            className="rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700 shadow"
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={p.image} alt={p.title} className="w-full h-48 object-cover" />
+            <div className="p-4 space-y-2">
+              <h3 className="text-2xl font-semibold">{p.title}</h3>
+              <p className="text-gray-700 dark:text-gray-300">{p.description}</p>
+            </div>
+          </div>
         ))}
-      </ul>
+      </div>
     </section>
   )
 }

--- a/src/app/technologies/page.tsx
+++ b/src/app/technologies/page.tsx
@@ -1,4 +1,5 @@
 import { technologies } from '@/lib/data'
+import TechBadge from '@/components/TechBadge'
 
 export default function TechnologiesPage() {
   return (
@@ -6,8 +7,8 @@ export default function TechnologiesPage() {
       <h2 className="text-4xl font-bold mb-4">Technologies</h2>
       <ul className="flex flex-wrap gap-2">
         {technologies.map((tech) => (
-          <li key={tech} className="px-2 py-1 bg-gray-200/40 dark:bg-gray-700/40 rounded">
-            {tech}
+          <li key={tech}>
+            <TechBadge name={tech} />
           </li>
         ))}
       </ul>

--- a/src/app/testimonials/page.tsx
+++ b/src/app/testimonials/page.tsx
@@ -2,8 +2,8 @@ import { testimonials } from '@/lib/data'
 
 export default function TestimonialsPage() {
   return (
-    <section className="space-y-6 py-10">
-      <h2 className="text-4xl font-bold mb-4">Testimonials</h2>
+    <section className="space-y-6 py-10 max-w-3xl mx-auto">
+      <h2 className="text-4xl font-bold mb-4 text-center">Testimonials</h2>
       <ul className="space-y-2">
         {testimonials.map((t) => (
           <li key={t.author} className="border-l-4 border-blue-500 pl-4">

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,7 +1,7 @@
 export default function Footer() {
   return (
     <footer className="mt-auto bg-gray-200/60 dark:bg-gray-800/60 backdrop-blur-md text-center p-4">
-      &copy; {new Date().getFullYear()} My Portfolio
+      &copy; {new Date().getFullYear()} Lo giudice Nicolas
     </footer>
   )
 }

--- a/src/components/TechBadge.tsx
+++ b/src/components/TechBadge.tsx
@@ -1,0 +1,79 @@
+import { ReactNode } from 'react'
+
+const icons: Record<string, ReactNode> = {
+  TypeScript: (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className="w-5 h-5"
+    >
+      <path
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2"
+        d="M3 5h18M3 5l9 14M21 5l-9 14"
+      />
+    </svg>
+  ),
+  React: (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className="w-5 h-5"
+    >
+      <path
+        stroke="currentColor"
+        strokeWidth="2"
+        d="M12 2a10 10 0 100 20 10 10 0 000-20z"
+      />
+      <path
+        fill="currentColor"
+        d="M12 7a5 5 0 100 10 5 5 0 000-10z"
+      />
+    </svg>
+  ),
+  'Next.js': (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className="w-5 h-5"
+    >
+      <path
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2"
+        d="M4 4l16 16M4 20L20 4"
+      />
+    </svg>
+  ),
+  TailwindCSS: (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className="w-5 h-5"
+    >
+      <path
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2"
+        d="M3 15s3-6 9-6 9 6 9 6"
+      />
+    </svg>
+  ),
+}
+
+export default function TechBadge({ name }: { name: string }) {
+  return (
+    <span className="flex items-center gap-1 px-2 py-1 bg-gray-200/40 dark:bg-gray-700/40 rounded">
+      {icons[name]}
+      <span>{name}</span>
+    </span>
+  )
+}

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1,12 +1,20 @@
 export const profile = {
   name: 'Lo giudice Nicolas',
   role: 'Full Stack Developer',
-  bio: 'A short bio about yourself. Replace this with your real bio.',
+  bio: 'Passionate developer focused on building performant and accessible web applications.',
 }
 
 export const projects = [
-  { title: 'Project One', description: 'Description of project one.' },
-  { title: 'Project Two', description: 'Description of project two.' },
+  {
+    title: 'Project One',
+    description: 'Description of project one.',
+    image: '/project1.svg',
+  },
+  {
+    title: 'Project Two',
+    description: 'Description of project two.',
+    image: '/project2.svg',
+  },
 ]
 
 export const technologies = ['TypeScript', 'React', 'Next.js', 'TailwindCSS']


### PR DESCRIPTION
## Summary
- add placeholder images and icons
- display profile photo on home and about pages
- enhance pages for projects, technologies, contact, and testimonials
- include simple Tailwind-style icons for technologies
- update footer with developer name

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876b7d9dfd88320b69c06b7ed0fcd57